### PR TITLE
Expand search for VHDL entity declarations.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ cat hdldepends.toml
 
 Now from a sub directory dump the VHDL work library compile order for a top level testbench
 ```
-hdldepends hdldepends.toml --top-file ../vhdl/example_tb.vhd --file-list-vhdl-lib work:compile_order.txt
+hdldepends hdldepends.toml --top-file ../vhdl/example_tb.vhd --compile-order-vhdl-lib work:compile_order.txt
 ```
 
 # Configuration file Keys/Options

--- a/src/hdldepends/hdldepends.py
+++ b/src/hdldepends/hdldepends.py
@@ -717,7 +717,7 @@ vhdl_regex_patterns = {
         re.DOTALL | re.IGNORECASE | re.MULTILINE,
     ),
     "entity_decl": re.compile(
-        r"(?<!:)\Wentity\s+(\w+)\s+is.*?end\s+(?:entity|\1)",
+        r"(?<!:)\Wentity\s+(\w+)\s+is.*?end\s*(?:entity|\1)?\s*;",
         re.DOTALL | re.IGNORECASE | re.MULTILINE,
     ),
     "vhdl_component_decl": re.compile(

--- a/test/vhdl/.gitignore
+++ b/test/vhdl/.gitignore
@@ -1,0 +1,2 @@
+hdl_deps_led_controller_tb.pickle
+led_controller_tb_compile_order.txt

--- a/test/vhdl/hdl_deps_led_controller_tb.toml
+++ b/test/vhdl/hdl_deps_led_controller_tb.toml
@@ -1,0 +1,2 @@
+vhdl_files_glob = ['./led_controller*.vhd']
+ignore_libs = ['ieee']

--- a/test/vhdl/led_controller_tb.vhd
+++ b/test/vhdl/led_controller_tb.vhd
@@ -1,0 +1,25 @@
+
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+entity led_controller_tb is
+end;
+
+architecture bench of led_controller_tb is
+  constant clk_period : time := 1 ns;
+  signal clk : std_logic                    := '1';
+  signal btn : std_logic_vector(1 downto 0) := (others => '0');
+  signal led : std_logic_vector(3 downto 0);
+begin
+
+  i_led_controller : entity work.led_controller
+    port map
+    (
+      clk => clk,
+      btn => btn,
+      led => led
+    );
+  clk <= not clk after clk_period/2;
+
+end;

--- a/test/vhdl/test_led_controller_tb.sh
+++ b/test/vhdl/test_led_controller_tb.sh
@@ -1,0 +1,17 @@
+check_file() {
+  if [ -f "$1" ]; then
+    return 0  # File exists
+  else
+    return 1  # File does not exist
+  fi
+}
+
+rm hdl_deps_led_controller_tb.pickle
+hdldepends hdl_deps_led_controller_tb.toml --top-entity led_controller_tb --compile-order-vhdl-lib work:led_controller_tb_compile_order.txt -vvv
+
+check_file "led_controller_tb_compile_order.txt"
+if [ $? -eq 0 ]; then
+    exit 0
+else
+    exit 1
+fi


### PR DESCRIPTION
Closes #4 

 + Entity block ending without 'entity' or '<entity_name>' will pass regex.
 + Add led_controller_tb test case.
 + Fixed top README VHDL lib compile order example.